### PR TITLE
touchmove が１度しか発生していない場合にページジャンプが起こるので、それを修正。

### DIFF
--- a/jquery.flicksimple.js
+++ b/jquery.flicksimple.js
@@ -290,8 +290,8 @@
 			var o = this;
 			var te = o.touchable ? e.originalEvent.touches[0] : e;
 			if ( o.disabled ) { return; }
-			o.startX = te.clientX;
-			o.startY = te.clientY;
+			o.startX = o.preX = te.clientX;
+			o.startY = o.preY = te.clientY;
 			o.touchhold = false;
 			var anc = e.target.tagName === 'A'
 				? $(e.target)


### PR DESCRIPTION
気が向いたら反映していただけると嬉しいです。
（２本指で高速でタップしまくってたらジャンプしました。なかなか見つからないバグだとは思います）
